### PR TITLE
グループリストの最新メッセージ表示機能の実装

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,6 +1,20 @@
 class Group < ApplicationRecord
   has_many :group_users
   has_many :users, through: :group_users
-  validates :name, presence: true, uniqueness: true
   has_many :messages
+
+  validates :name, presence: true, uniqueness: true
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      if last_message.content?
+        last_message.content
+      else
+        "画像が投稿されています。"
+      end
+    else
+      "まだメッセージはありません。"
+    end
+  end
+
 end

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -8,14 +8,18 @@
     .chat-main__group-info__edit
       = link_to "#", class: "edit" do
         Edit
+
   .chat-main__message-list
     = render @messages
+
   .chat-main__message-form
     = form_for [@group, @message] do |f|
-      = f.text_field :content, class: ".chat-main__message-form__text-box", placeholder: "type a message"
-      .chat-main__message-form__text-box__input
-        = f.label :image,class:".chat-main__message-form__text-box__input__icon" do
-          = icon("far", "image", class: "icon")
-          = f.file_field :image, class: ".chat-main__message-form__text-box__icon__file"
-      = f.submit "Send", class: ".chat-main__message-form__btn"
+      .chat-main__message-form__input
+        = f.text_field :content, class: ".chat-main__message-form__input__text-box", placeholder: "type a message"
+        .chat-main__message-form__input__box
+          = f.label :image,class:".chat-main__message-form__input__box__icon" do
+            = icon("far", "image", class: "icon")
+            = f.file_field :image, class: ".chat-main__message-form__input__box__icon__file"
+        = f.submit "Send", class: ".chat-main__message-form__btn"
+
     

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -15,5 +15,5 @@
           .side-bar__group-list__link__name
             = group.name
           .side-bar__group-list__link__message
-            メッセージはまだありません
+            = group.show_last_message
 


### PR DESCRIPTION
# What
グループリストのグループ個別に、最新のメッセージが表示されるように実装した。

# Why
最新メッセージが表示された方がユーザーも使いやすいため。